### PR TITLE
use memoffset::raw_field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+memoffset = "0.5.4"
 
 [build-dependencies]
 rustc_version = "0.2.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,13 +147,29 @@ impl<T, U> Clone for FieldOffset<T, U> {
 ///
 /// Examples:
 ///
-/// Offset of field `Foo().bar`
+/// Offset of field `Foo.bar`
 ///
-/// `offset_of!(Foo => bar)`
+/// ```rust
+/// # #[macro_use]
+/// # extern crate field_offset;
+/// # fn main() {
+/// #[repr(C)]
+/// struct Foo { foo: i32, bar: i32 }
+/// assert_eq!(offset_of!(Foo => bar).get_byte_offset(), 4);
+/// # }
+/// ```
 ///
-/// Offset of nested field `Foo().bar.x`
+/// Offset of nested field `Foo.bar.x`
 ///
-/// `offset_of!(Foo => bar: Bar => x)`
+/// ```rust
+/// # #[macro_use]
+/// # extern crate field_offset;
+/// # fn main() {
+/// struct Bar { a: u8, x: u8 }
+/// struct Foo { foo: i32, bar: Bar }
+/// assert_eq!(offset_of!(Foo => bar: Bar => x).get_byte_offset(), 5);
+/// # }
+/// ```
 #[macro_export]
 macro_rules! offset_of {
     ($t: tt => $f: tt) => {{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::mem;
 use std::ops::Add;
 use std::fmt;
 
+#[doc(hidden)]
 pub extern crate memoffset as __memoffset; // `pub` for macro availability
 
 /// Represents a pointer to a field of type `U` within the type `T`


### PR DESCRIPTION
Use the new `raw_field!` macro from memoffset (https://github.com/Gilnaa/memoffset/pull/40) to do the raw-ptr-offsetting here. This moves the burden of UB down to that crate (where it already is for `memoffset::offset_of!`).

I also added doctests, which are quite useful for macros because (unlike unit tests), they exercise the macro from *outside* the current crate.

This is meant to gather feedback for whether the new API in memoffset is adequate, before we make a release. I used `path` dependencies to be able to locally use memoffset with the new macro.