### PR TITLE
Allow FieldOffset to be constructed from a const offset

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 extern crate rustc_version;
-use rustc_version::{version, Version};
+use rustc_version::{version, version_meta, Channel, Version};
 
 fn main() {
     // Assert we haven't travelled back in time
@@ -8,5 +8,9 @@ fn main() {
     // Check for a minimum version
     if version().unwrap() >= Version::parse("1.36.0").unwrap() {
         println!("cargo:rustc-cfg=fieldoffset_maybe_uninit");
+    }
+
+    if version_meta().unwrap().channel == Channel::Nightly {
+        println!("cargo:rustc-cfg=fieldoffset_assert_in_const_fn");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,9 @@ impl<T, U> FieldOffset<T, U> {
         // actually a field.
         #[cfg(fieldoffset_assert_in_const_fn)]
         assert!(offset + mem::size_of::<U>() <= mem::size_of::<T>());
+        // On stable rust, we can still get an assert in debug mode,
+        // relying on the checked overflow behaviour
+        let _ = mem::size_of::<T>() - (offset + mem::size_of::<U>());
 
         FieldOffset(offset, PhantomData)
     }


### PR DESCRIPTION
My use case is that i have a procedural macro that generate const field offsets from `#[repr(C)] struct` in a associated const. I would like to re use the `FieldOffset` struct from this crate, but in order for that to work, i need to be able to construct `FieldOffset` in a const context. Hence this patch.

A few note: 
 - PhantomData with fn or dyn trait cannot be constructed in a const context on stable. But using one level of indirection works.
 - assert! cannot be used in a const fn on stable. I kept it with feature gates on nightly, but it is otherwise removed. The assert is not necessary to maintain the invariant anyway as this function should only be called safely with valid offset.
