### PR TITLE
Mark the crate as #![no_std]

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,7 @@ fn main() {
     // Check for a minimum version
     if version().unwrap() >= Version::parse("1.36.0").unwrap() {
         println!("cargo:rustc-cfg=fieldoffset_maybe_uninit");
+        println!("cargo:rustc-cfg=fieldoffset_has_alloc");
     }
 
     if version_meta().unwrap().channel == Channel::Nightly {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 // which are too lax.
 #![allow(clippy::needless_lifetimes)]
 
-#[cfg(test)]
+#[cfg(all(test, fieldoffset_has_alloc))]
 extern crate alloc;
 
 use core::fmt;
@@ -494,6 +494,7 @@ mod tests {
         );
     }
 
+    #[cfg(fieldoffset_has_alloc)]
     #[test]
     fn test_pin() {
         use alloc::boxed::Box;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![cfg_attr(fieldoffset_assert_in_const_fn, feature(const_panic))]
 #![cfg_attr(fieldoffset_assert_in_const_fn, feature(const_fn))]
 // Explicit lifetimes are clearer when we are working with raw pointers,
@@ -5,11 +6,14 @@
 // which are too lax.
 #![allow(clippy::needless_lifetimes)]
 
-use std::fmt;
-use std::marker::PhantomData;
-use std::mem;
-use std::ops::Add;
-use std::pin::Pin;
+#[cfg(test)]
+extern crate alloc;
+
+use core::fmt;
+use core::marker::PhantomData;
+use core::mem;
+use core::ops::Add;
+use core::pin::Pin;
 
 #[doc(hidden)]
 pub extern crate memoffset as __memoffset; // `pub` for macro availability
@@ -492,7 +496,8 @@ mod tests {
 
     #[test]
     fn test_pin() {
-        use std::pin::Pin;
+        use alloc::boxed::Box;
+        use core::pin::Pin;
 
         // Get a pointer to `b` within `Foo`
         let foo_b = offset_of!(Foo => b);


### PR DESCRIPTION
Just because we can ;-)

Btw, I'd appreciate a new release of the crate on crates.io  (with or without this change)