### PR TITLE
Add const_if_match feature to fix compiler errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
-#![cfg_attr(fieldoffset_assert_in_const_fn, feature(const_panic))]
+#![cfg_attr(fieldoffset_assert_in_const_fn, feature(const_if_match))]
 #![cfg_attr(fieldoffset_assert_in_const_fn, feature(const_fn))]
+#![cfg_attr(fieldoffset_assert_in_const_fn, feature(const_panic))]
 // Explicit lifetimes are clearer when we are working with raw pointers,
 // as the compiler will not warn us if we specify lifetime constraints
 // which are too lax.


### PR DESCRIPTION
Fix for https://github.com/Diggsey/rust-field-offset/issues/13