### PR TITLE
Update memoffset to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "field-offset"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Diggory Blake <diggsey@googlemail.com>"]
 description = "Safe pointer-to-member implementation"
 repository = "https://github.com/Diggsey/rust-field-offset"
@@ -8,7 +8,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-memoffset = "0.5.4"
+memoffset = "0.6.0"
 
 [build-dependencies]
-rustc_version = "0.2.3"
+rustc_version = "0.3.0"


### PR DESCRIPTION
Since `memoffset`'s internals are not exposed to the user, I've only updated the `field-offset`'s minor version.