### PR TITLE
Update to memoffset 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "field-offset"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Diggory Blake <diggsey@googlemail.com>"]
 description = "Safe pointer-to-member implementation"
 repository = "https://github.com/Diggsey/rust-field-offset"
@@ -8,7 +8,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-memoffset = "0.6.0"
+memoffset = "0.7.1"
 
 [build-dependencies]
 rustc_version = "0.4.0"


### PR DESCRIPTION
A bot might want to be set up to create pr's that checks for updates to packages.

The newest `memoffset` has no breaking changes so no work other than a version bump is required.