### PR TITLE
Make FieldOffset covariant with the field type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,12 +52,12 @@ pub struct FieldOffset<T, U, PinFlag = NotPinned>(
     ///     of.apply(foo)
     /// }
     /// ```
-    PhantomData<(PhantomContra<T>, U, PinFlag)>,
+    PhantomData<(PhantomFn<T, U>, PinFlag)>,
 );
 
 /// `fn` cannot appear directly in a type that need to be const.
 /// Workaround that with an indirection
-struct PhantomContra<T>(fn(T));
+struct PhantomFn<T, U>(fn(T) -> U);
 
 /// Type that can be used in the `PinFlag` parameter of `FieldOffset` to specify that
 /// this projection is valid on Pin types.


### PR DESCRIPTION
The documentation states:
> A pointer-to-member can be thought of as a function from `&T` to `&U`

This updates the`PhantomData` field to better reflect that statement. Importantly, this removes the `U:` constraints on auto trait impls, making e.g. `FieldOffset<T, U>: Sync` even if `U: !Sync`.